### PR TITLE
Selected output emits a number[]

### DIFF
--- a/src/products/components/pizza-form/pizza-form.component.ts
+++ b/src/products/components/pizza-form/pizza-form.component.ts
@@ -92,7 +92,7 @@ export class PizzaFormComponent implements OnChanges {
   @Input() pizza: Pizza;
   @Input() toppings: Topping[];
 
-  @Output() selected = new EventEmitter<Pizza>();
+  @Output() selected = new EventEmitter<number[]>();
   @Output() create = new EventEmitter<Pizza>();
   @Output() update = new EventEmitter<Pizza>();
   @Output() remove = new EventEmitter<Pizza>();


### PR DESCRIPTION
Selected output emits a `number[]` instead of a `Pizza`, this was a copy/paste error because in the container components you've typed the event correctly as a `number[]`